### PR TITLE
Fix Chrome startup and ignore SSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore debug screenshots and logs
+debug_screenshots/
+*.log

--- a/scraper.py
+++ b/scraper.py
@@ -33,6 +33,10 @@ def init_driver():
     chrome_options.add_argument("--disable-dev-shm-usage")
     chrome_options.add_argument("--no-sandbox")
     chrome_options.add_argument("--window-size=1920,1080")
+    # Ignore certificate errors to avoid privacy error page in restricted
+    # environments
+    chrome_options.add_argument("--ignore-certificate-errors")
+    chrome_options.add_argument("--allow-running-insecure-content")
     chrome_options.add_argument(
         "user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36")
 


### PR DESCRIPTION
## Summary
- add a `.gitignore` to avoid committing debug screenshots
- update `init_driver` to ignore certificate errors so Chrome can load the target site in restricted environments

## Testing
- `apt-get update`
- `apt-get install -y chromium-browser chromium-chromedriver` *(installs a snap stub; later install real chrome)*
- `wget ... google-chrome-stable_current_amd64.deb && apt-get install -y /tmp/google-chrome.deb`
- `pip3 install selenium webdriver-manager`
- `python3 scraper.py` *(runs but fails to scrape due to site structure; shows property processing output)*

------
https://chatgpt.com/codex/tasks/task_e_688cb7c536c88325922cd7a116d3baea